### PR TITLE
@import prevent using the pod in project not supporting modules

### DIFF
--- a/Source/UIView+Shake.h
+++ b/Source/UIView+Shake.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Fancy Pixel. All rights reserved.
 //
 
-@import UIKit;
+#import UIKit;
 
 /** @enum ShakeDirection
  *


### PR DESCRIPTION
Using the [`@import` syntax](https://github.com/andreamazz/UIView-Shake/blob/master/Source/UIView%2BShake.h#L9) prevent the pod to build if included in project disabling modules.

See [this StackOverflow question for the same issue in the GoogleAnalytics pod](https://stackoverflow.com/questions/32314151/ios-cocoapods-how-to-resolve-use-of-import-when-modules-are-disabled-erro).

Using the `@import` syntax does not provides much, as `#import` will still use modules as long as the project opted-in to use them:

> You don't actually need to use the `@import` keyword. If you opt-in to using modules, all `#import` and `#include` directives are mapped to use `@import` automatically.

https://stackoverflow.com/questions/18947516/import-vs-import-ios-7
